### PR TITLE
Fix broken talks list layout (broken when in mobile)

### DIFF
--- a/views/screen.scss
+++ b/views/screen.scss
@@ -148,12 +148,13 @@ sup {
 
 ul.talks {
   li {
+    position: relative;
     color: rgba(255,255,255,0.5);
     margin: 0 0 6px;
     span {
       color: rgba(255,255,255,1);
       float: left;
-      padding: 0 0 0 8px;
+      padding: 0 0 0 24px;
       strong {
         a {
           color: rgba(255,255,255,1);
@@ -175,7 +176,8 @@ ul.talks {
       font-size: 90%;
     }
     img {
-      float: left;
+      position: absolute;
+      top: 0; left: 0;
       margin: 5px 0 0;
       @include border-radius(1px);
     }


### PR DESCRIPTION
## Before

:fearful:
![before](http://f.cl.ly/items/0B0D3M1I26071T1Y2b0e/before.png)
## After

:sunglasses:
![after](http://f.cl.ly/items/3F3M1d2B0W2G1d434234/after.png)
